### PR TITLE
Handle single-character input in Huffman encoding

### DIFF
--- a/Huffman.cs
+++ b/Huffman.cs
@@ -93,7 +93,10 @@ class Huffman
         // Найден листовой узел
         if (root.left == null && root.right == null)
         {
-            huffmanCode[root.ch] = str;
+            // При наличии единственного уникального символа код может оказаться пустым,
+            // что приведёт к потере данных при кодировании. В этом случае присваиваем
+            // символу хотя бы один бит (например, "0").
+            huffmanCode[root.ch] = str.Length > 0 ? str : "0";
         }
 
         Encode(root.left, str + "0", huffmanCode);


### PR DESCRIPTION
## Summary
- ensure Huffman encoding assigns a bit even when only one unique symbol exists

## Testing
- `mcs -target:library Huffman.cs`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68c6b5019960833092c8e821b663fff7)